### PR TITLE
Fixes #38

### DIFF
--- a/handlers/main.yml
+++ b/handlers/main.yml
@@ -106,6 +106,7 @@
     returncode=0
     {% for interface in all_interfaces_changed | reverse %}
     ifdown {% if ansible_os_family == 'Debian' %}--allow auto {% endif %}{{ interface }};
+    ip addr flush {{interface}};
     {% endfor %}
 
     {% for interface in all_interfaces_changed %}


### PR DESCRIPTION
This commit implements an additional ip addr flush on the changed interfaces before running a ifup,
this prevents #38 to happen.